### PR TITLE
Add Wavebox support

### DIFF
--- a/.github/update-versions.js
+++ b/.github/update-versions.js
@@ -6,6 +6,7 @@
 //   Vivaldi  -- download .deb, run strings on binary
 //   Atlas    -- download macOS DMG via Sparkle appcast, extract plist
 //   Dia      -- download macOS ZIP via Sparkle appcast, run strings on binary
+//   Wavebox  -- download .deb, run strings on binary
 //
 // Requires: Node 20+, p7zip-full (for .deb and Atlas DMG extraction)
 // Usage:    node update-versions.js
@@ -84,23 +85,26 @@ async function downloadDeb(url, label) {
   return { path, tmp };
 }
 
-// Extract data.tar from a .deb using 7z. 7z auto-decompresses xz, so the
-// result is always a plain data.tar. Works on both macOS and Linux (unlike
-// BSD ar on macOS which can't handle some .deb formats).
+// Extract data.tar from a .deb using 7z. Works on both macOS and Linux
+// (unlike BSD ar on macOS which can't handle some .deb formats).
 function extractDataTar(debPath, tmpDir) {
   const dataDir = join(tmpDir, "deb-data");
   execSync(`${SZ} x -o"${dataDir}" "${debPath}" -y 2>&1`, {
     timeout: 60_000,
   });
-  // 7z auto-decompresses xz, so we get data.tar (not data.tar.xz)
   const tarPath = join(dataDir, "data.tar");
-  try {
-    readFileSync(tarPath, { flag: "r" });
-    return tarPath;
-  } catch {
-    // Fallback: maybe 7z kept it as data.tar.xz
-    return join(dataDir, "data.tar.xz");
+  try { readFileSync(tarPath, { flag: "r" }); return tarPath; } catch {}
+
+  for (const compressed of ["data.tar.xz", "data.tar.zst"]) {
+    const compressedPath = join(dataDir, compressed);
+    try { readFileSync(compressedPath, { flag: "r" }); } catch { continue; }
+    execSync(`${SZ} x -o"${dataDir}" "${compressedPath}" -y 2>&1`, {
+      timeout: 60_000,
+    });
+    try { readFileSync(tarPath, { flag: "r" }); return tarPath; } catch {}
+    return compressedPath;
   }
+  throw new Error("data.tar not found in .deb");
 }
 
 // Compare two dotted version strings (e.g., "147.0.7727.117" > "146.0.7680.201").
@@ -113,8 +117,9 @@ function versionCompare(a, b) {
   return 0;
 }
 
-// Tar flag: -J for .xz, nothing for plain .tar
+// Tar flag: -J for .xz, --zstd for .zst, nothing for plain .tar
 function tarFlag(path) {
+  if (path.endsWith(".zst")) return "--zstd -xf";
   return path.endsWith(".xz") ? "-xJf" : "-xf";
 }
 
@@ -222,6 +227,23 @@ async function detectVivaldi() {
       console.log("  Standard extraction failed, trying broad search...");
       ver = extractChromeVersionBroadSearch(dataTar, binaryPath);
     }
+    console.log("  Found: " + ver);
+    return { chromiumVersion: ver, chromiumMajor: parseInt(ver, 10) };
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+async function detectWavebox() {
+  const url = "https://download.wavebox.app/latest/stable/linux/deb";
+  const { path, tmp } = await downloadDeb(url, "wavebox");
+  try {
+    console.log("  Extracting Chromium version...");
+    const dataTar = extractDataTar(path, tmp);
+    const ver = extractChromeVersionFromDeb(
+      dataTar,
+      "./opt/wavebox.io/wavebox/wavebox"
+    );
     console.log("  Found: " + ver);
     return { chromiumVersion: ver, chromiumMajor: parseInt(ver, 10) };
   } finally {
@@ -419,6 +441,7 @@ const browsers = [
   { key: "vivaldi", name: "Vivaldi Stable", detect: detectVivaldi, source: "extracted from Linux .deb binary" },
   { key: "atlas", name: "ChatGPT Atlas", detect: detectAtlas, source: "extracted from macOS DMG plist" },
   { key: "dia", name: "Dia", detect: detectDia, source: "extracted from macOS ZIP binary" },
+  { key: "wavebox", name: "Wavebox", detect: detectWavebox, source: "extracted from Linux .deb binary" },
 ];
 
 const jsonPath = new URL("../ci-versions.json", import.meta.url).pathname;

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ https://chromium-drift.pages.dev
 7. Perplexity Comet
 8. Arc
 9. Dia
+10. Wavebox
 
 ## Docs
 

--- a/ci-versions.json
+++ b/ci-versions.json
@@ -22,5 +22,11 @@
     "lastUpdated": "2026-05-01",
     "source": "extracted from macOS ZIP binary",
     "chromiumVersion": "147.0.7727.138"
+  },
+  "wavebox": {
+    "chromiumMajor": 147,
+    "lastUpdated": "2026-05-05",
+    "source": "extracted from Linux .deb binary",
+    "chromiumVersion": "147.0.7727.102"
   }
 }

--- a/docs/version-fetching.md
+++ b/docs/version-fetching.md
@@ -43,3 +43,7 @@ Fetches the Sparkle appcast to find the latest DMG URL, downloads the DMG, extra
 ### Dia
 
 Fetches the Sparkle appcast at `releases.diabrowser.com/BoostBrowser-updates.xml` to find the latest ZIP URL, downloads the macOS ZIP, extracts the app binary using 7z, and runs `strings` to find the embedded `Chrome/X.X.X.X` UA string.
+
+### Wavebox
+
+Downloads the Wavebox Linux .deb package from `download.wavebox.app`, extracts the `wavebox` binary, and uses `strings` to find the embedded `Chrome/X.X.X.X` UA string.

--- a/functions/api.js
+++ b/functions/api.js
@@ -132,6 +132,7 @@ const ciBrowsers = [
   { name: "Opera Stable", key: "opera" },
   { name: "ChatGPT Atlas", key: "atlas" },
   { name: "Dia", key: "dia" },
+  { name: "Wavebox", key: "wavebox" },
 ];
 
 function fromEntry(name, entry, sourcePrefix) {

--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
   <script>
     const ORDER = [
       "Chrome Stable", "Brave Release", "Vivaldi Stable",
-      "Comet", "Opera Stable", "Edge Stable", "Arc", "Dia",
+      "Comet", "Opera Stable", "Edge Stable", "Arc", "Dia", "Wavebox",
     ];
 
     const DOCS_BASE = "https://github.com/ShivanKaul/chromium-drift/blob/main/docs/version-fetching.md#";
@@ -298,6 +298,7 @@
       "Opera Stable": "opera-stable",
       "ChatGPT Atlas": "chatgpt-atlas",
       "Dia": "dia",
+      "Wavebox": "wavebox",
     };
 
     function cardUrl(e) {

--- a/manual-versions.json
+++ b/manual-versions.json
@@ -7,5 +7,6 @@
   "comet": {},
   "atlas": {},
   "arc": {},
-  "dia": {}
+  "dia": {},
+  "wavebox": {}
 }

--- a/test/test.js
+++ b/test/test.js
@@ -315,6 +315,16 @@ await test("Dia appcast: extracts ZIP URL from highest build", () => {
   assert(items[0][2] === "https://releases.diabrowser.com/release/Dia-1.28.0-79513.zip", "should pick highest build ZIP");
 });
 
+await test("Wavebox .deb binary path is stable", () => {
+  const files = [
+    "./opt/wavebox.io/wavebox/chrome-sandbox",
+    "./opt/wavebox.io/wavebox/wavebox",
+    "./opt/wavebox.io/wavebox/wavebox-launcher",
+  ];
+  const binary = files.find((p) => p === "./opt/wavebox.io/wavebox/wavebox");
+  assert(binary, "should find Wavebox binary path");
+});
+
 // ---------------------------------------------------------------------------
 // Integration tests: real API calls
 // ---------------------------------------------------------------------------
@@ -498,6 +508,16 @@ await test("Dia: Sparkle appcast has ZIP enclosure", async () => {
   assert(items.length > 0, "should have at least one item with a ZIP URL");
   items.sort((a, b) => Number(b[1]) - Number(a[1]));
   assert(items[0][2].startsWith("https://"), "ZIP URL should be HTTPS");
+});
+
+await test("Wavebox: latest Linux .deb endpoint resolves to package", async () => {
+  const r = await f("https://download.wavebox.app/latest/stable/linux/deb", {
+    method: "HEAD",
+    redirect: "follow",
+  });
+  assert(r.url.endsWith(".deb"), "final URL should be a .deb");
+  const len = parseInt(r.headers.get("content-length") || "0", 10);
+  assert(len > 100 * 1024 * 1024, "package should have a realistic content length");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Adds Wavebox as a CI-detected browser, which is read from the deb at https://download.wavebox.app/latest/stable/linux/deb

It extracts Wavebox and reads the embedded Chrome/X.X.X.X version, matching the existing flows. I also added support to handle zstd-compressed payloads to the deb extractor.

P.S. Great to see the linkout to https://chromiumchecker.com/ 😉