### PR TITLE
use `googlechromelabs.github.io` for more accurate chrome versions

### DIFF
--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -41,38 +41,12 @@ export function ok(browser, chromiumVersion, chromiumMajor, source, sourceUrl = 
 
 // --- Chrome ---
 export async function chrome() {
-  // fetch_releases includes early stable rollouts, so we check the latest
-  // milestone's schedule to see if stable_date has passed. If not, we use
-  // the previous milestone.
   const r = await f(
-    "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10"
+    "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE"
   );
-  const releases = await r.json();
-  if (!releases.length) throw new Error("empty");
-
-  const latest = releases[0];
-  const sched = await f(
-    "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=" + latest.milestone
-  );
-  const data = await sched.json();
-  const stableDate = data.mstones?.[0]?.stable_date;
-
-  // Chrome rolls out gradually, so wait until the day after the official
-  // stable_date (in Pacific Time) before treating the new milestone as current.
-  const stableDatePassed = !stableDate || (() => {
-    // Get today's date in Pacific Time as YYYY-MM-DD
-    const todayPT = new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
-    // The stable_date from the API is a date string (e.g. "2026-05-05").
-    // We require todayPT to be strictly after the stable_date.
-    return todayPT > stableDate.slice(0, 10);
-  })();
-  if (stableDatePassed) {
-    return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  }
-  // Latest is still early stable; use previous milestone
-  const prev = releases.find((rel) => rel.milestone < latest.milestone);
-  if (prev) return ok("Chrome Stable", prev.version, prev.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
+  const version = await r.text();
+  const milestone = parseInt(version.split(".")[0], 10);
+  return ok("Chrome Stable", version, milestone, "source: public API (googlechromelabs.github.io, macOS)", "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_STABLE");
 }
 
 // --- Edge ---


### PR DESCRIPTION
The previous endpoint used from `chromiumdash.appspot.com` seems to be a
bit inconsistent in how it orders its versions. For example, as of the
release of Chromium 152:

- Release 153 is first
- **151 is second**
- 152 is third

This breaks the current logic of assuming the first version in the
list with an older milestone than the yet-to-be-released stable is the
currently released stable

We could further this complicate this function to try and account for
that, but this endpoint is *much* easier to get the info we actually
want from, while just as fast to update AFAIK
