### PR TITLE
fix: use served Chrome stable release

### DIFF
--- a/docs/version-fetching.md
+++ b/docs/version-fetching.md
@@ -6,9 +6,7 @@ Chromium versions for these browsers are fetched live on page load. The fetching
 
 ### Chrome Stable
 
-Calls `chromiumdash.appspot.com/fetch_releases` for the latest macOS stable release. The JSON response includes the full version and milestone directly.
-
-Because Chrome rolls out new stable versions gradually, the dashboard also checks the milestone schedule (`fetch_milestone_schedule`) and waits until the day after the official `stable_date` (in Pacific Time) before treating a new milestone as current. Until then, the previous milestone is shown.
+Calls the [Chrome Version History API](https://developer.chrome.com/docs/web-platform/versionhistory/guide) for macOS stable releases. The response includes the currently served builds and their rollout `fraction`; the fetcher selects the build with the highest served fraction and uses the highest version when fractions are tied. This avoids mistaking an early rollout for the current stable release.
 
 ### Brave Release
 

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -40,39 +40,23 @@ export function ok(browser, chromiumVersion, chromiumMajor, source, sourceUrl = 
 }
 
 // --- Chrome ---
+export function selectChromeRelease(releases) {
+  return [...releases]
+    .filter((release) => release?.version && Number(release.fraction) > 0)
+    .sort((a, b) => {
+      const fractionDiff = Number(b.fraction) - Number(a.fraction);
+      if (fractionDiff) return fractionDiff;
+      return b.version.localeCompare(a.version, undefined, { numeric: true });
+    })[0];
+}
+
 export async function chrome() {
-  // fetch_releases includes early stable rollouts, so we check the latest
-  // milestone's schedule to see if stable_date has passed. If not, we use
-  // the previous milestone.
-  const r = await f(
-    "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10"
-  );
-  const releases = await r.json();
-  if (!releases.length) throw new Error("empty");
-
-  const latest = releases[0];
-  const sched = await f(
-    "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=" + latest.milestone
-  );
-  const data = await sched.json();
-  const stableDate = data.mstones?.[0]?.stable_date;
-
-  // Chrome rolls out gradually, so wait until the day after the official
-  // stable_date (in Pacific Time) before treating the new milestone as current.
-  const stableDatePassed = !stableDate || (() => {
-    // Get today's date in Pacific Time as YYYY-MM-DD
-    const todayPT = new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
-    // The stable_date from the API is a date string (e.g. "2026-05-05").
-    // We require todayPT to be strictly after the stable_date.
-    return todayPT > stableDate.slice(0, 10);
-  })();
-  if (stableDatePassed) {
-    return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  }
-  // Latest is still early stable; use previous milestone
-  const prev = releases.find((rel) => rel.milestone < latest.milestone);
-  if (prev) return ok("Chrome Stable", prev.version, prev.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
+  const sourceUrl = "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=endtime=none";
+  const r = await f(sourceUrl);
+  const data = await r.json();
+  const release = selectChromeRelease(data.releases || []);
+  if (!release) throw new Error("no served stable release");
+  return ok("Chrome Stable", release.version, parseInt(release.version, 10), "source: public API (versionhistory.googleapis.com, macOS)", sourceUrl);
 }
 
 // --- Edge ---

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+import { selectChromeRelease } from "../lib/fetchers.js";
+
 // Tests for the Chromium version fetchers.
 // Run with: node test.js
 //
@@ -42,6 +44,16 @@ async function test(name, fn) {
 // ---------------------------------------------------------------------------
 
 console.log("\nParsing tests\n");
+
+await test("Chrome Version History: selects the most-served build", () => {
+  const release = selectChromeRelease([
+    { version: "152.0.7977.77", fraction: 0.25 },
+    { version: "152.0.7977.76", fraction: 0.5 },
+    { version: "152.0.7977.83", fraction: 1 },
+    { version: "153.0.8000.1", fraction: 0 }
+  ]);
+  assert(release.version === "152.0.7977.83", "should select the fully served build");
+});
 
 await test("Vivaldi appcast: extracts release notes link", () => {
   const xml = `<?xml version="1.0"?>


### PR DESCRIPTION
## Summary
Switch Chrome Stable detection to the official Chrome Version History API.

## Changes
- select from currently served stable builds using rollout fraction
- use the highest version when multiple builds have the same serving fraction
- remove the ChromiumDash milestone schedule workaround
- update version-fetching documentation and add deterministic coverage

## Verification
- [x] node test/test.js
- [x] 42 tests passed

Fixes #27