### PR TITLE
use `versionhistory.googleapis.com` for more accurate chrome versions

### DIFF
--- a/docs/version-fetching.md
+++ b/docs/version-fetching.md
@@ -6,9 +6,9 @@ Chromium versions for these browsers are fetched live on page load. The fetching
 
 ### Chrome Stable
 
-Calls `chromiumdash.appspot.com/fetch_releases` for the latest macOS stable release. The JSON response includes the full version and milestone directly.
+Calls `https://versionhistory.googleapis.com` for the latest macOS stable release.
 
-Because Chrome rolls out new stable versions gradually, the dashboard also checks the milestone schedule (`fetch_milestone_schedule`) and waits until the day after the official `stable_date` (in Pacific Time) before treating a new milestone as current. Until then, the previous milestone is shown.
+Because Chrome rolls out new stable versions gradually, we find all currently "live" releases and assume the newest one that can be [pinned](https://support.google.com/chrome/a/answer/6350036) by system administrators to be the latest. This should be a safe assumption as you cannot pin [Chrome Variation](https://developer.chrome.com/docs/web-platform/chrome-variations) releases, only those found in the [Chrome Release blog](https://chromereleases.googleblog.com/search/label/Stable%20updates+Desktop%20Update) for example.
 
 ### Brave Release
 

--- a/lib/fetchers.js
+++ b/lib/fetchers.js
@@ -41,38 +41,16 @@ export function ok(browser, chromiumVersion, chromiumMajor, source, sourceUrl = 
 
 // --- Chrome ---
 export async function chrome() {
-  // fetch_releases includes early stable rollouts, so we check the latest
-  // milestone's schedule to see if stable_date has passed. If not, we use
-  // the previous milestone.
-  const r = await f(
-    "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10"
-  );
-  const releases = await r.json();
-  if (!releases.length) throw new Error("empty");
-
-  const latest = releases[0];
-  const sched = await f(
-    "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=" + latest.milestone
-  );
-  const data = await sched.json();
-  const stableDate = data.mstones?.[0]?.stable_date;
-
-  // Chrome rolls out gradually, so wait until the day after the official
-  // stable_date (in Pacific Time) before treating the new milestone as current.
-  const stableDatePassed = !stableDate || (() => {
-    // Get today's date in Pacific Time as YYYY-MM-DD
-    const todayPT = new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
-    // The stable_date from the API is a date string (e.g. "2026-05-05").
-    // We require todayPT to be strictly after the stable_date.
-    return todayPT > stableDate.slice(0, 10);
-  })();
-  if (stableDatePassed) {
-    return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  }
-  // Latest is still early stable; use previous milestone
-  const prev = releases.find((rel) => rel.milestone < latest.milestone);
-  if (prev) return ok("Chrome Stable", prev.version, prev.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
-  return ok("Chrome Stable", latest.version, latest.milestone, "source: public API (chromiumdash.appspot.com, macOS)", "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=10");
+  const u = "https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc";
+  const r = await f(u);
+  const d = await r.json();
+  // "Pinnable" versions are the full releases we're expecting, rather than anything from a rollout or A/B testing
+  // Not documented in the official reference, but thankfully Google open sourced this API
+  // https://github.com/googleapis/google-api-go-client/blob/dfa9e13aa3e07a6283a6497f744ba5c4785a54fc/versionhistory/v1/versionhistory-api.json#L474-L477
+  const v = d.releases.find((v) => v.pinnable).version;
+  if (!v) throw new Error("No \"pinnable\" Chrome release found. Something may be wrong");
+  const m = parseInt(v, 10);
+  return ok("Chrome Stable", v, m, "source: public API (versionhistory.googleapis.com, macOS)", u);
 }
 
 // --- Edge ---

--- a/test/test.js
+++ b/test/test.js
@@ -157,82 +157,6 @@ await test("Chromium version broad search: filters by third component > 1000", (
   assert(candidates.includes("146.0.7680.211"), "should include Chromium version");
 });
 
-await test("Chrome schedule: stable_date rollout buffer logic", () => {
-  // The chrome() function gets today in PT as YYYY-MM-DD and checks
-  // todayPT > stableDate (strictly after), giving a 1-day buffer.
-  // Simulate the comparison logic here.
-  function stableDatePassed(stableDate, fakeTodayPT) {
-    return fakeTodayPT > stableDate.slice(0, 10);
-  }
-
-  // On the stable_date itself, the version should NOT be considered current
-  assert(!stableDatePassed("2026-05-05", "2026-05-05"), "same day: should not pass");
-
-  // The day after, it should pass
-  assert(stableDatePassed("2026-05-05", "2026-05-06"), "day after: should pass");
-
-  // The day before, it should not pass
-  assert(!stableDatePassed("2026-05-05", "2026-05-04"), "day before: should not pass");
-
-  // Well after the stable_date
-  assert(stableDatePassed("2026-05-05", "2026-06-01"), "month after: should pass");
-
-  // Handles year boundary
-  assert(stableDatePassed("2025-12-31", "2026-01-01"), "year boundary: should pass");
-  assert(!stableDatePassed("2026-01-01", "2025-12-31"), "year boundary: should not pass");
-});
-
-await test("Chrome schedule: todayPT uses America/Los_Angeles timezone", () => {
-  // Verify that toLocaleDateString with en-CA + America/Los_Angeles produces YYYY-MM-DD
-  const todayPT = new Date().toLocaleDateString("en-CA", { timeZone: "America/Los_Angeles" });
-  assert(/^\d{4}-\d{2}-\d{2}$/.test(todayPT), "should be YYYY-MM-DD format, got: " + todayPT);
-});
-
-await test("Chrome schedule: handles stableDate with time/timezone suffix", () => {
-  // The API may return dates like "2026-05-05T00:00:00" or with timezone info.
-  // .slice(0, 10) should extract just the date part.
-  function stableDatePassed(stableDate, fakeTodayPT) {
-    return fakeTodayPT > stableDate.slice(0, 10);
-  }
-  assert(!stableDatePassed("2026-05-05T00:00:00", "2026-05-05"), "ISO datetime: same day should not pass");
-  assert(stableDatePassed("2026-05-05T00:00:00", "2026-05-06"), "ISO datetime: day after should pass");
-  assert(!stableDatePassed("2026-05-05T23:59:59Z", "2026-05-05"), "ISO with Z: same day should not pass");
-  assert(stableDatePassed("2026-05-05T23:59:59Z", "2026-05-06"), "ISO with Z: day after should pass");
-  assert(stableDatePassed("2026-05-05T12:00:00-07:00", "2026-05-06"), "ISO with offset: day after should pass");
-});
-
-await test("Chrome schedule: leap year date handling", () => {
-  function stableDatePassed(stableDate, fakeTodayPT) {
-    return fakeTodayPT > stableDate.slice(0, 10);
-  }
-  // Feb 29 in a leap year
-  assert(!stableDatePassed("2028-02-29", "2028-02-29"), "leap day: same day should not pass");
-  assert(stableDatePassed("2028-02-29", "2028-03-01"), "leap day: Mar 1 should pass");
-  assert(!stableDatePassed("2028-02-29", "2028-02-28"), "leap day: Feb 28 should not pass");
-});
-
-await test("Chrome schedule: DST transition dates (spring forward/fall back)", () => {
-  // Spring forward 2026: March 8 (US). Fall back 2026: November 1 (US).
-  // The string comparison approach is immune to DST issues, but verify anyway.
-  function stableDatePassed(stableDate, fakeTodayPT) {
-    return fakeTodayPT > stableDate.slice(0, 10);
-  }
-  // Spring forward
-  assert(!stableDatePassed("2026-03-08", "2026-03-08"), "spring forward day: same day should not pass");
-  assert(stableDatePassed("2026-03-08", "2026-03-09"), "spring forward day: day after should pass");
-  // Fall back
-  assert(!stableDatePassed("2026-11-01", "2026-11-01"), "fall back day: same day should not pass");
-  assert(stableDatePassed("2026-11-01", "2026-11-02"), "fall back day: day after should pass");
-});
-
-await test("Chrome schedule: no stableDate means version is considered current", () => {
-  // When stableDate is null/undefined, the code treats it as already passed.
-  // Mirrors the `!stableDate || ...` check in api.js.
-  const stableDate = null;
-  const passed = !stableDate || "2026-05-06" > "2026-05-05";
-  assert(passed, "null stableDate should be treated as passed");
-});
-
 await test("Brave versions.json: finds release channel entry", () => {
   const data = {
     "v1.91.88": { channel: "nightly", dependencies: { chrome: "147.0.7727.102" } },
@@ -383,25 +307,6 @@ await test("Helium chromium_version.txt: rejects invalid formats", () => {
 // ---------------------------------------------------------------------------
 
 console.log("\nIntegration tests (hitting real APIs)\n");
-
-await test("Chrome: ChromiumDash returns valid release", async () => {
-  const r = await f(
-    "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Mac&num=1"
-  );
-  const data = await r.json();
-  assert(data.length > 0, "should return at least one release");
-  assert(typeof data[0].milestone === "number", "milestone should be a number");
-  assert(/^\d+\.\d+\.\d+\.\d+$/.test(data[0].version), "version should be x.x.x.x format");
-});
-
-await test("Chrome: milestone schedule returns stable_date", async () => {
-  const r = await f(
-    "https://chromiumdash.appspot.com/fetch_milestone_schedule?mstone=147"
-  );
-  const data = await r.json();
-  assert(data.mstones?.length > 0, "should have mstones");
-  assert(data.mstones[0].stable_date, "should have stable_date");
-});
 
 await test("Edge: returns Stable product with releases", async () => {
   const r = await f("https://edgeupdates.microsoft.com/api/products");


### PR DESCRIPTION
Fixes: https://github.com/ShivanKaul/chromium-drift/issues/27
Supersedes: https://github.com/ShivanKaul/chromium-drift/pull/26

Alternative take from https://github.com/ShivanKaul/chromium-drift/pull/28 and the initial concept from the issue:

- Determining latest release by fraction makes little sense when new releases [are regularly rolled out slowly](https://chromium.googlesource.com/chromium/src/+/master/docs/process/release_cycle.md#Stable-Promotion). We're trying to find the latest version from the stable channel, not what version Google wants most people to be on right now
- The [`order_by`](https://developer.chrome.com/docs/web-platform/versionhistory/reference#order) query param is used in the request rather than making some messy sorting ourselves. I have no idea why this wasn't done before, aside from an LLM not reading the full API reference
- Tests are gone! This implementation is simple enough to where we don't even really have any logic here *to* test, let alone the release schedule stuff that was dealt with before. I didn't bother updating the integration tests either, as they were practically just making sure the API worked and did respond with a valid schema at that time...which *really* isn't testing anything in this project